### PR TITLE
Enable the API extensions to work with the NoopTracer. As the NoopTra…

### DIFF
--- a/opentracing-api-extensions-tracer/pom.xml
+++ b/opentracing-api-extensions-tracer/pom.xml
@@ -31,6 +31,20 @@
     </dependency>
 
     <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-noop</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-util</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-mock</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <scope>test</scope>

--- a/opentracing-api-extensions-tracer/src/main/java/io/opentracing/contrib/api/tracer/APIExtensionsSpanBuilder.java
+++ b/opentracing-api-extensions-tracer/src/main/java/io/opentracing/contrib/api/tracer/APIExtensionsSpanBuilder.java
@@ -48,52 +48,68 @@ public class APIExtensionsSpanBuilder implements SpanBuilder {
 
     @Override
     public SpanBuilder asChildOf(SpanContext parent) {
-        wrappedBuilder.asChildOf(parent);
+        if (wrappedBuilder != null) {
+            wrappedBuilder.asChildOf(parent);
+        }
         return this;
     }
 
     @Override
     public SpanBuilder asChildOf(BaseSpan<?> parent) {
-        wrappedBuilder.asChildOf(parent);
+        if (wrappedBuilder != null) {
+            wrappedBuilder.asChildOf(parent);
+        }
         return this;
     }
 
     @Override
     public SpanBuilder addReference(String referenceType, SpanContext referencedContext) {
-        wrappedBuilder.addReference(referenceType, referencedContext);
+        if (wrappedBuilder != null) {
+            wrappedBuilder.addReference(referenceType, referencedContext);
+        }
         return this;
     }
 
     @Override
     public SpanBuilder ignoreActiveSpan() {
-        wrappedBuilder.ignoreActiveSpan();
+        if (wrappedBuilder != null) {
+            wrappedBuilder.ignoreActiveSpan();
+        }
         return this;
     }
 
     @Override
     public SpanBuilder withTag(String key, String value) {
         tags.put(key, value);
-        wrappedBuilder.withTag(key, value);
+        if (wrappedBuilder != null) {
+            wrappedBuilder.withTag(key, value);
+        }
         return this;
     }
 
     @Override
     public SpanBuilder withTag(String key, boolean value) {
         tags.put(key, value);
-        wrappedBuilder.withTag(key, value);
+        if (wrappedBuilder != null) {
+            wrappedBuilder.withTag(key, value);
+        }
         return this;
     }
 
     @Override
     public SpanBuilder withTag(String key, Number value) {
         tags.put(key, value);
-        wrappedBuilder.withTag(key, value);
+        if (wrappedBuilder != null) {
+            wrappedBuilder.withTag(key, value);
+        }
         return this;
     }
 
     @Override
     public SpanBuilder withStartTimestamp(long microseconds) {
-        wrappedBuilder.withStartTimestamp(microseconds);
+        if (wrappedBuilder != null) {
+            wrappedBuilder.withStartTimestamp(microseconds);
+        }
         // Reset the nano start time, so that duration will be calculated based on explicitly
         // provided timestamps
         this.startTimeNano = 0;
@@ -107,7 +123,8 @@ public class APIExtensionsSpanBuilder implements SpanBuilder {
 
     @Override
     public Span startManual() {
-        APIExtensionsSpan span = new APIExtensionsSpan(wrappedBuilder.startManual(),
+        APIExtensionsSpan span = new APIExtensionsSpan(
+                (wrappedBuilder == null ? null : wrappedBuilder.startManual()),
                 operationName, startTimestampMicro, startTimeNano, tags);
         for (TracerObserver observer : observers) {
             span.addSpanObserver(observer.onStart(span));

--- a/opentracing-api-extensions-tracer/src/test/java/io/opentracing/contrib/api/tracer/APIExtensionsFullSpanLifecycleTest.java
+++ b/opentracing-api-extensions-tracer/src/test/java/io/opentracing/contrib/api/tracer/APIExtensionsFullSpanLifecycleTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.api.tracer;
+
+import org.junit.Test;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
+
+import io.opentracing.NoopTracerFactory;
+import io.opentracing.contrib.api.SpanData;
+import io.opentracing.contrib.api.SpanObserver;
+import io.opentracing.contrib.api.TracerObserver;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.util.ThreadLocalActiveSpanSource;
+
+public class APIExtensionsFullSpanLifecycleTest {
+
+    @Test
+    public void testMockTracerActiveSpan() {
+        APIExtensionsTracer extTracer = new APIExtensionsTracer(new MockTracer(new ThreadLocalActiveSpanSource()));
+        TracerObserver tracerObserver = Mockito.mock(TracerObserver.class);
+        SpanObserver spanObserver = Mockito.mock(SpanObserver.class);
+        Mockito.when(tracerObserver.onStart(Matchers.any(SpanData.class))).thenReturn(spanObserver);
+        extTracer.addTracerObserver(tracerObserver);
+
+        extTracer.buildSpan("testOp").startActive().deactivate();
+        
+        Mockito.verify(spanObserver, Mockito.times(1)).onFinish(Matchers.any(SpanData.class), Matchers.anyLong());
+    }
+
+    @Test
+    public void testMockTracerManualSpan() {
+        APIExtensionsTracer extTracer = new APIExtensionsTracer(new MockTracer());
+        TracerObserver tracerObserver = Mockito.mock(TracerObserver.class);
+        SpanObserver spanObserver = Mockito.mock(SpanObserver.class);
+        Mockito.when(tracerObserver.onStart(Matchers.any(SpanData.class))).thenReturn(spanObserver);
+        extTracer.addTracerObserver(tracerObserver);
+
+        extTracer.buildSpan("testOp").startManual().finish();
+        
+        Mockito.verify(spanObserver, Mockito.times(1)).onFinish(Matchers.any(SpanData.class), Matchers.anyLong());
+    }
+
+    @Test
+    public void testNoopTracerActiveSpan() {
+        APIExtensionsTracer extTracer = new APIExtensionsTracer(NoopTracerFactory.create());
+        TracerObserver tracerObserver = Mockito.mock(TracerObserver.class);
+        SpanObserver spanObserver = Mockito.mock(SpanObserver.class);
+        Mockito.when(tracerObserver.onStart(Matchers.any(SpanData.class))).thenReturn(spanObserver);
+        extTracer.addTracerObserver(tracerObserver);
+
+        extTracer.buildSpan("testOp").startActive().deactivate();
+        
+        Mockito.verify(spanObserver, Mockito.times(1)).onFinish(Matchers.any(SpanData.class), Matchers.anyLong());
+    }
+
+    @Test
+    public void testNoopTracerManualSpan() {
+        APIExtensionsTracer extTracer = new APIExtensionsTracer(NoopTracerFactory.create());
+        TracerObserver tracerObserver = Mockito.mock(TracerObserver.class);
+        SpanObserver spanObserver = Mockito.mock(SpanObserver.class);
+        Mockito.when(tracerObserver.onStart(Matchers.any(SpanData.class))).thenReturn(spanObserver);
+        extTracer.addTracerObserver(tracerObserver);
+
+        extTracer.buildSpan("testOp").startManual().finish();
+        
+        Mockito.verify(spanObserver, Mockito.times(1)).onFinish(Matchers.any(SpanData.class), Matchers.anyLong());
+    }
+
+}

--- a/opentracing-api-extensions-tracer/src/test/java/io/opentracing/contrib/api/tracer/APIExtensionsTracerTest.java
+++ b/opentracing-api-extensions-tracer/src/test/java/io/opentracing/contrib/api/tracer/APIExtensionsTracerTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import io.opentracing.ActiveSpan;
+import io.opentracing.NoopTracerFactory;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
 
@@ -48,12 +49,15 @@ public class APIExtensionsTracerTest {
     @Test
     public void testBuild() {
         Tracer tracer = Mockito.mock(Tracer.class);
-        ActiveSpan activeSpan = Mockito.mock(ActiveSpan.class);
-        Span span = Mockito.mock(Span.class);
-        Mockito.when(tracer.makeActive(span)).thenReturn(activeSpan);
         
         APIExtensionsTracer extTracer = new APIExtensionsTracer(tracer);
-        extTracer.buildSpan("testop");
+        assertTrue(extTracer.buildSpan("testop") instanceof APIExtensionsSpanBuilder);
+    }
+
+    @Test
+    public void testBuildNoopTracer() {
+        APIExtensionsTracer extTracer = new APIExtensionsTracer(NoopTracerFactory.create());
+        assertTrue(extTracer.buildSpan("testop") instanceof APIExtensionsSpanBuilder);
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,11 @@
       </dependency>
       <dependency>
         <groupId>io.opentracing</groupId>
+        <artifactId>opentracing-noop</artifactId>
+        <version>${version.io.opentracing}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.opentracing</groupId>
         <artifactId>opentracing-mock</artifactId>
         <version>${version.io.opentracing}</version>
       </dependency>


### PR DESCRIPTION
…cer does not create any actual spans, it becomes a problem when the application is using active spans with the ActiveSpanSource, resulting in no observer callbacks being performed. This PR deals with the problem by ignoring the NoopTracer and instead creating its own span instances - these are then managed by the ActiveSpanSource and correctly get notified when the span finishes.