### PR TITLE
Implemented opentracing-api 0.32.0-RC2

### DIFF
--- a/opentracing-api-extensions-tracer/src/main/java/io/opentracing/contrib/api/tracer/APIExtensionsSpan.java
+++ b/opentracing-api-extensions-tracer/src/main/java/io/opentracing/contrib/api/tracer/APIExtensionsSpan.java
@@ -25,6 +25,7 @@ import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.contrib.api.SpanData;
 import io.opentracing.contrib.api.SpanObserver;
+import io.opentracing.tag.Tag;
 
 public class APIExtensionsSpan implements Span, SpanData  {
 
@@ -92,6 +93,16 @@ public class APIExtensionsSpan implements Span, SpanData  {
     @Override
     public Object getCorrelationId() {
         return correlationId;
+    }
+
+    @Override
+    public String getTraceId() {
+        return context().toTraceId();
+    }
+
+    @Override
+    public String getSpanId() {
+        return context().toSpanId();
     }
 
     @Override
@@ -210,6 +221,14 @@ public class APIExtensionsSpan implements Span, SpanData  {
         return handleSetTag(key, value);
     }
 
+    @Override
+    public <T> Span setTag(Tag<T> tag, T value) {
+        if (wrappedSpan != null) {
+            wrappedSpan.setTag(tag, value);
+        }
+        return handleSetTag(tag.getKey(), value);
+    }
+
     private Span handleSetTag(String key, Object value) {
         tags.put(key, value);
         for (SpanObserver observer : observers) {
@@ -286,6 +305,16 @@ public class APIExtensionsSpan implements Span, SpanData  {
 
     static class SpanContextImpl implements NoopSpanContext {
         static final SpanContextImpl INSTANCE = new SpanContextImpl();
+
+        @Override
+        public String toTraceId() {
+            return "";
+        }
+
+        @Override
+        public String toSpanId() {
+            return "";
+        }
 
         @Override
         public Iterable<Map.Entry<String, String>> baggageItems() {

--- a/opentracing-api-extensions-tracer/src/main/java/io/opentracing/contrib/api/tracer/APIExtensionsSpanBuilder.java
+++ b/opentracing-api-extensions-tracer/src/main/java/io/opentracing/contrib/api/tracer/APIExtensionsSpanBuilder.java
@@ -13,18 +13,19 @@
  */
 package io.opentracing.contrib.api.tracer;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
-
 import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.Tracer.SpanBuilder;
 import io.opentracing.contrib.api.TracerObserver;
+import io.opentracing.tag.Tag;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 public class APIExtensionsSpanBuilder implements SpanBuilder {
 
@@ -100,6 +101,15 @@ public class APIExtensionsSpanBuilder implements SpanBuilder {
         tags.put(key, value);
         if (wrappedBuilder != null) {
             wrappedBuilder.withTag(key, value);
+        }
+        return this;
+    }
+
+    @Override
+    public <T> SpanBuilder withTag(Tag<T> tag, T value) {
+        tags.put(tag.getKey(), value);
+        if (wrappedBuilder != null) {
+            wrappedBuilder.withTag(tag, value);
         }
         return this;
     }

--- a/opentracing-api-extensions-tracer/src/main/java/io/opentracing/contrib/api/tracer/APIExtensionsTracer.java
+++ b/opentracing-api-extensions-tracer/src/main/java/io/opentracing/contrib/api/tracer/APIExtensionsTracer.java
@@ -13,17 +13,19 @@
  */
 package io.opentracing.contrib.api.tracer;
 
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
-import io.opentracing.noop.NoopTracer;
+import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.contrib.api.APIExtensionsManager;
 import io.opentracing.contrib.api.TracerObserver;
+import io.opentracing.noop.NoopTracer;
 import io.opentracing.propagation.Format;
 import io.opentracing.util.ThreadLocalScopeManager;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 public class APIExtensionsTracer implements Tracer, APIExtensionsManager {
 
@@ -61,6 +63,11 @@ public class APIExtensionsTracer implements Tracer, APIExtensionsManager {
             return wrappedTracer.activeSpan();
         }
         return scopeManager.active() == null ? null : scopeManager.active().span();
+    }
+
+    @Override
+    public Scope activateSpan(Span span) {
+        return scopeManager().activate(span);
     }
 
     @Override

--- a/opentracing-api-extensions/src/main/java/io/opentracing/contrib/api/SpanData.java
+++ b/opentracing-api-extensions/src/main/java/io/opentracing/contrib/api/SpanData.java
@@ -33,6 +33,10 @@ public interface SpanData {
      */
     Object getCorrelationId();
 
+    String getTraceId();
+
+    String getSpanId();
+
     /**
      * The start time of the {@link io.opentracing.Span}.
      *

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <maven.compiler.target>1.7</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.opentracing>0.31.0</version.io.opentracing>
+    <version.io.opentracing>0.32.0-RC2</version.io.opentracing>
     <version.io.opentracing.contrib.tracerresolver>0.1.5</version.io.opentracing.contrib.tracerresolver>
     <version.junit>4.12</version.junit>
     <version.org.mockito-mockito-all>1.10.19</version.org.mockito-mockito-all>


### PR DESCRIPTION
Fixes #17 

When 0.32.0 get's a proper release you'll only need to change the version then. Assuming no other changes will make it into that release that require additional adjustments.